### PR TITLE
Update custom-status guide for v14.

### DIFF
--- a/docs/setup/discord/custom-status.md
+++ b/docs/setup/discord/custom-status.md
@@ -5,7 +5,10 @@ hide_table_of_contents: false
 sidebar_position: 3
 ---
 
-1. Locate line 360 of [backend/src/index.ts](https://github.com/Dragory/ZeppelinBot/blob/master/backend/src/index.ts#L360).
+1. Add the following import to [backend/src/index.ts](https://github.com/Dragory/ZeppelinBot/blob/master/backend/src/index.ts).
+   ```ts
+   import { ActivityType } from "discord.js"
+   ```
 2. Add e.g.,
 
    ```ts

--- a/docs/setup/discord/custom-status.md
+++ b/docs/setup/discord/custom-status.md
@@ -10,7 +10,7 @@ sidebar_position: 3
 
    ```ts
    client.user?.setPresence({
-     activities: [{ name: "zeppelins", type: "WATCHING" }],
+     activities: [{ name: "zeppelins", type: ActivityType.Watching }],
    });
    ```
 

--- a/docs/setup/discord/custom-status.md
+++ b/docs/setup/discord/custom-status.md
@@ -14,7 +14,7 @@ sidebar_position: 3
    });
    ```
 
-   to line 360 (under `startUptimeCounter()`).
+   to line 360 (under `startUptimeCounter()`). You can find all of the different ActivityType's [here](https://discord-api-types.dev/api/discord-api-types-v10/enum/ActivityType).
 
    ![custom activity](/img/guides/discord/custom_activity.png "Custom Activity")
 


### PR DESCRIPTION
Previously you were able to provide a `string` for `type` when setting the client's presence, now you have to provide an `ActivityType` such as `ActivityType.Watching`